### PR TITLE
Nit fix on naming

### DIFF
--- a/src/tools/sui/get-balance.ts
+++ b/src/tools/sui/get-balance.ts
@@ -1,5 +1,5 @@
 import { SuiAgentKit } from "../../index";
-import {isValidSuiAddress} from "../../utils/validate-token-address";
+import {isValidSuiTokenAddress} from "../../utils/validate-token-address";
 
 const MIST_PER_SUI = 1000000000;
 
@@ -14,7 +14,7 @@ export async function getBalance(
   token_address?: string,
 ): Promise<number> {
     try {
-        if (!isValidSuiAddress(token_address)) {
+        if (!isValidSuiTokenAddress(token_address)) {
             console.log('No token address provided, defaulting to SUI balance');
             token_address = "0x2::sui::SUI";
         }

--- a/src/utils/validate-token-address.ts
+++ b/src/utils/validate-token-address.ts
@@ -1,10 +1,10 @@
-export function isValidSuiAddress(address: string | undefined): boolean {
+export function isValidSuiTokenAddress(address: string | undefined): boolean {
     if (!address) {
         return false;
     }
 
-    const suiAddressRegex = /^0x[a-fA-F0-9]{64}(::[a-zA-Z0-9_]+)*$/;
-    const isValid = suiAddressRegex.test(address);
+    const suiTokenAddressRegex = /^0x[a-fA-F0-9]{64}(::[a-zA-Z0-9_]+)*$/;
+    const isValid = suiTokenAddressRegex.test(address);
 
     if (!isValid) {
         console.error(`Invalid SUI address: ${address}`);


### PR DESCRIPTION
This pull request includes changes to the `src/tools/sui/get-balance.ts` and `src/utils/validate-token-address.ts` files to improve the consistency and clarity of function naming related to SUI token address validation.

The most important changes include:

* **Function Renaming for Clarity:**
  * Renamed `isValidSuiAddress` to `isValidSuiTokenAddress` in `src/utils/validate-token-address.ts` to better reflect its purpose.
  * Updated all references to the renamed function in `src/tools/sui/get-balance.ts` to maintain consistency. [[1]](diffhunk://#diff-b4a454083417bfaf82e2a169c7b0e180a63c18246548055ad3b3acdc37ebeb08L2-R2) [[2]](diffhunk://#diff-b4a454083417bfaf82e2a169c7b0e180a63c18246548055ad3b3acdc37ebeb08L17-R17)