### PR TITLE
Rename stake

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,7 +2,7 @@ import { Config } from '../types';
 import { SuiClient, SuiHTTPTransport } from '@mysten/sui/client';
 import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
 import { Ed25519Keypair, Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519';
-import { getBalance, tradeByCetus, tradeByNavi, transfer, stake, depositBySuilend } from '../tools';
+import { getBalance, tradeByCetus, tradeByNavi, transfer, stakeBySpringsui, depositBySuilend } from '../tools';
 
 /**
  * Main class for interacting with Sui blockchain
@@ -67,7 +67,7 @@ export class SuiAgentKit {
   }
 
   async stake(amount: number, tokenAddress: string): Promise<string> {
-    return stake(this, amount, tokenAddress);
+    return stakeBySpringsui(this, amount, tokenAddress);
   }
 
   async deposit(coinType: string, amount: number): Promise<string> {

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -11,7 +11,7 @@ import {
     SuiGetBalanceTool,
     SuiCetusTradeTool,
     SuiTransferTool,
-    SuiStakeTool,
+    SuiSpringsuiStakeTool,
     SuiNaviTradeTool,
     SuiSuilendDepositTool
 } from "./index";
@@ -22,7 +22,7 @@ export function createSuiTools(suiAgentKit: SuiAgentKit) {
     new SuiGetBalanceTool(suiAgentKit),
     new SuiCetusTradeTool(suiAgentKit),
     new SuiTransferTool(suiAgentKit),
-    new SuiStakeTool(suiAgentKit),
+    new SuiSpringsuiStakeTool(suiAgentKit),
     new SuiNaviTradeTool(suiAgentKit),
     new SuiSuilendDepositTool(suiAgentKit)
   ];

--- a/src/langchain/suilend/stake-by-springsui.ts
+++ b/src/langchain/suilend/stake-by-springsui.ts
@@ -1,7 +1,7 @@
 import { Tool } from "langchain/tools";
 import { SuiAgentKit } from "../../agent";
 
-export class SuiStakeTool extends Tool {
+export class SuiSpringsuiStakeTool extends Tool {
     name = "sui_stake";
     description = `Use this tool to stake your SUI or other supported coins with Spring Sui (liquid staking).
 

--- a/src/tools/suilend/stake-by-springsui.ts
+++ b/src/tools/suilend/stake-by-springsui.ts
@@ -12,7 +12,7 @@ import { MIST_PER_SUI, SUIVISION_URL } from "../../constants";
  * @returns {Promise<string>} A promise that resolves to a JSON string containing the status, message, and transaction details.
  * @throws {Error} If the staking process fails, an error is thrown with a message indicating the failure reason.
  */
-export async function stake(
+export async function stakeBySpringsui(
     agent: SuiAgentKit,
     amount: number,
     lstTokenAddress: string,


### PR DESCRIPTION
This pull request includes changes to update the staking functionality to use Spring Sui's liquid staking. The most important changes involve renaming functions and classes to reflect this update and modifying the imports accordingly.

### Updates to staking functionality:

* [`src/agent/index.ts`](diffhunk://#diff-cb5ca0323ba2dea08805490561c6f6be57d76c591a9d77483851d56b55f68821L5-R5): Updated the import statement to replace `stake` with `stakeBySpringsui`, and modified the `stake` method in the `SuiAgentKit` class to use `stakeBySpringsui`. [[1]](diffhunk://#diff-cb5ca0323ba2dea08805490561c6f6be57d76c591a9d77483851d56b55f68821L5-R5) [[2]](diffhunk://#diff-cb5ca0323ba2dea08805490561c6f6be57d76c591a9d77483851d56b55f68821L70-R70)

* [`src/langchain/index.ts`](diffhunk://#diff-279bbfa2e984898fe64e62b4b82ff1273c76dfc5f9c597cb94d5d72a155fe6e0L14-R14): Changed the import of `SuiStakeTool` to `SuiSpringsuiStakeTool` and updated the `createSuiTools` function to use `SuiSpringsuiStakeTool`. [[1]](diffhunk://#diff-279bbfa2e984898fe64e62b4b82ff1273c76dfc5f9c597cb94d5d72a155fe6e0L14-R14) [[2]](diffhunk://#diff-279bbfa2e984898fe64e62b4b82ff1273c76dfc5f9c597cb94d5d72a155fe6e0L25-R25)

* [`src/langchain/suilend/stake-by-springsui.ts`](diffhunk://#diff-ae5b037dc1d99b378b6b40f66be2b41a513d519fda5eff02019b5a95deef7f0fL4-R4): Renamed the file from `stake.ts` and updated the class name from `SuiStakeTool` to `SuiSpringsuiStakeTool`.

* [`src/tools/suilend/stake-by-springsui.ts`](diffhunk://#diff-74977ddc10eeb33f2def393174ef62e747ee3a41555b51091eb95f141a558bf1L15-R15): Renamed the file from `stake.ts` and updated the function name from `stake` to `stakeBySpringsui`.