### PR TITLE
Refactor request body to include wallet address

### DIFF
--- a/examples/nextjs-wallet-langchain/app/api/chat/route.ts
+++ b/examples/nextjs-wallet-langchain/app/api/chat/route.ts
@@ -36,7 +36,10 @@ const agent = createReactAgent({
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const messages = body.messages ?? [];
+    const messages = body.message ? [{ role: JSON.parse(body.message)['role'], content: JSON.parse(body.message)['content']}] : [];
+
+    const address = body.requestData;
+    suiAgent.walletAddress = address;
 
     const eventStream = agent.streamEvents(
       {

--- a/examples/nextjs-wallet-langchain/components/ChatWindow.tsx
+++ b/examples/nextjs-wallet-langchain/components/ChatWindow.tsx
@@ -5,6 +5,7 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 import { useChat } from 'ai/react';
+import { JSONValue } from 'ai';
 import { useRef, useState, ReactElement } from 'react';
 import type { FormEvent } from 'react';
 
@@ -35,7 +36,7 @@ export function ChatWindow(props: {
   const [showIntermediateSteps, setShowIntermediateSteps] = useState(false);
   const [intermediateStepsLoading, setIntermediateStepsLoading] =
     useState(false);
-  const { signAndExecuteTransaction, chain } = useWallet();
+  const { signAndExecuteTransaction, address } = useWallet();
   const suiClient = useSuiClient();
 
   const intemediateStepsToggle = showIntermediateStepsToggle && (
@@ -77,6 +78,9 @@ export function ChatWindow(props: {
           [messageIndexHeader]: sources,
         });
       }
+    },
+    experimental_prepareRequestBody: ({messages}) => {
+      return { message: JSON.stringify(messages[messages.length - 1]), requestData: address as JSONValue };
     },
     onFinish: async (message) => {
       try {


### PR DESCRIPTION
This pull request includes several updates to the `examples/nextjs-wallet-langchain` project, focusing on improving the handling of chat messages and wallet addresses. The most important changes include adjustments to the `POST` function in the `chat/route.ts` file, updates to the `ChatWindow` component to use the wallet address, and the addition of a new method to prepare the request body.

Improvements to chat message handling and wallet address integration:

* [`examples/nextjs-wallet-langchain/app/api/chat/route.ts`](diffhunk://#diff-c24b3b91ce47fb7ad463421a3f2bc5ea746b6aa6ef9074660707a3882304ab14L39-R42): Modified the `POST` function to parse and handle a single message and set the wallet address from the request data.

Updates to the `ChatWindow` component:

* [`examples/nextjs-wallet-langchain/components/ChatWindow.tsx`](diffhunk://#diff-e17d29b70e84f277cdade934ccd2c2a6eb086f03ed9c6729addac84848c9acdeR8): Imported `JSONValue` from `ai` to handle JSON data types.
* [`examples/nextjs-wallet-langchain/components/ChatWindow.tsx`](diffhunk://#diff-e17d29b70e84f277cdade934ccd2c2a6eb086f03ed9c6729addac84848c9acdeL38-R39): Replaced `chain` with `address` in the `useWallet` hook to use the wallet address.
* [`examples/nextjs-wallet-langchain/components/ChatWindow.tsx`](diffhunk://#diff-e17d29b70e84f277cdade934ccd2c2a6eb086f03ed9c6729addac84848c9acdeR82-R84): Added `experimental_prepareRequestBody` method to prepare the request body with the latest message and wallet address.