### PR TITLE
Fix get balance number to big number

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@suilend/sdk": "^1.1.36",
     "@suilend/springsui-sdk": "^1.0.17",
     "navi-sdk": "^1.4.23",
-    "@suilend/frontend-sui": "^0.2.38"
+    "@suilend/frontend-sui": "^0.2.38",
+    "bignumber.js": "^9.1.2"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       ai:
         specifier: ^4.1.26
         version: 4.1.26(react@19.0.0)(zod@3.24.1)
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       bn.js:
         specifier: ^5.2.1
         version: 5.2.1

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -72,7 +72,7 @@ export class SuiAgentKit {
     return true;
   }
 
-  async getBalance(tokenAddress?: string): Promise<bigint> {
+  async getBalance(tokenAddress?: string): Promise<string> {
     return getBalance(this, tokenAddress);
   }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -72,7 +72,7 @@ export class SuiAgentKit {
     return true;
   }
 
-  async getBalance(tokenAddress?: string): Promise<number> {
+  async getBalance(tokenAddress?: string): Promise<bigint> {
     return getBalance(this, tokenAddress);
   }
 

--- a/src/langchain/sui/get-balance.ts
+++ b/src/langchain/sui/get-balance.ts
@@ -1,6 +1,7 @@
 import { Tool } from "langchain/tools"
 import { SuiAgentKit } from '../../agent';
 import { TOKENS } from "../../constants";
+import { string } from "zod";
 
 export class SuiGetBalanceTool extends Tool {
     name = "sui_balance";
@@ -34,10 +35,10 @@ export class SuiGetBalanceTool extends Tool {
             }
             
             const balance = await this.suiAgentKit.getBalance(tokenAddress);
-
+            
             return JSON.stringify({
                 status: "success",
-                balance,
+                balance: balance.toString(),
                 token: input || "SUI",
             });
         } catch (error: any) {

--- a/src/langchain/sui/get-balance.ts
+++ b/src/langchain/sui/get-balance.ts
@@ -38,7 +38,7 @@ export class SuiGetBalanceTool extends Tool {
             
             return JSON.stringify({
                 status: "success",
-                balance: balance.toString(),
+                balance,
                 token: input || "SUI",
             });
         } catch (error: any) {

--- a/src/tools/sui/get-balance.ts
+++ b/src/tools/sui/get-balance.ts
@@ -1,6 +1,7 @@
 import { SuiAgentKit } from '../../index';
 import { isValidSuiTokenAddress } from '../../utils/validate-token-address';
 import { TOKENS, MIST_PER_SUI } from '../../constants';
+import BigNumber from "bignumber.js";
 
 /**
  * Retrieves the balance of a specified token for a given agent.
@@ -13,7 +14,7 @@ import { TOKENS, MIST_PER_SUI } from '../../constants';
 export async function getBalance(
   agent: SuiAgentKit,
   tokenAddress?: string
-): Promise<bigint> {
+): Promise<string> {
   try {
     if (!agent.walletAddress) {
       throw new Error('Wallet not connected');
@@ -37,7 +38,9 @@ export async function getBalance(
       coinType: tokenAddress,
     });
  
-    return BigInt(balanceResponse.totalBalance) / BigInt(10 ** fromCoinAddressMetadata.decimals);
+    return BigNumber(balanceResponse.totalBalance)
+      .dividedBy(10 ** fromCoinAddressMetadata.decimals)
+      .toFixed(2).toString();
   } catch (error: any) {
     console.error(
       'Error getting balance:',


### PR DESCRIPTION
This pull request includes several changes to improve the handling of balance calculations, including the introduction of the `bignumber.js` library for more accurate balance computations. The most important changes are detailed below.

### Dependency Updates:
* Added `bignumber.js` version `^9.1.2` to `dependencies` in `package.json`.
* Added `bignumber.js` version `9.1.2` to `importers` in `pnpm-lock.yaml`.

### Code Changes:
* Changed the return type of the `getBalance` method in `SuiAgentKit` class from `number` to `string` in `src/agent/index.ts`.
* Updated the `getBalance` function in `src/tools/sui/get-balance.ts` to use `BigNumber` for balance calculations and return a string value. This includes fetching coin metadata to determine the correct decimal places for the balance. [[1]](diffhunk://#diff-b4a454083417bfaf82e2a169c7b0e180a63c18246548055ad3b3acdc37ebeb08R4) [[2]](diffhunk://#diff-b4a454083417bfaf82e2a169c7b0e180a63c18246548055ad3b3acdc37ebeb08L16-R17) [[3]](diffhunk://#diff-b4a454083417bfaf82e2a169c7b0e180a63c18246548055ad3b3acdc37ebeb08R27-R43)
* Added import of `BigNumber` in `src/tools/sui/get-balance.ts`.

These changes ensure more precise balance calculations and improve the robustness of the code by handling different token decimal places appropriately.